### PR TITLE
Add pipeline processing for devserver

### DIFF
--- a/OUTPUT
+++ b/OUTPUT
@@ -1,1 +1,0 @@
-goodbye

--- a/cmslib/src/core/broker.rs
+++ b/cmslib/src/core/broker.rs
@@ -2,10 +2,9 @@ use std::sync::Arc;
 use std::{collections::HashSet, path::PathBuf};
 
 use crate::devserver::{DevServerMsg, DevServerReceiver, DevServerSender};
+use crate::page::RenderedPage;
 use crate::CanonicalPath;
 use tokio::runtime::Handle;
-
-use crate::core::engine::RenderedPage;
 
 type EngineSender = async_channel::Sender<EngineMsg>;
 type EngineReceiver = async_channel::Receiver<EngineMsg>;
@@ -80,7 +79,13 @@ impl FilesystemUpdateEvents {
 
 #[derive(Debug)]
 pub enum EngineMsg {
+    /// A group of files have been updated. This will trigger a page
+    /// reload after processing is complete. Events are batched by
+    /// the filesystem watcher using debouncing, so only one reload
+    /// message is fired for multiple changes.
     FilesystemUpdate(FilesystemUpdateEvents),
+    /// Renders a page and then returns it on the channel supplied in
+    /// the request.
     RenderPage(RenderPageRequest),
     /// Builds the site using existing configuration and source material
     Build,

--- a/cmslib/src/devserver/fswatcher.rs
+++ b/cmslib/src/devserver/fswatcher.rs
@@ -63,6 +63,7 @@ pub fn start_watching<P: AsRef<Path> + std::fmt::Debug>(
                     add_event(&mut events, ev);
                 }
                 Err(_) => {
+                    trace!(events = ?events, "sending filesystem update events");
                     broker
                         .send_engine_msg_sync(EngineMsg::FilesystemUpdate(events))
                         .expect("error communicating with engine from filesystem watcher");

--- a/cmslib/src/pagestore.rs
+++ b/cmslib/src/pagestore.rs
@@ -75,8 +75,8 @@ impl PageStore {
         }
     }
 
-    pub fn iter(&self) -> impl Iterator<Item = &Page> {
-        self.pages.iter().map(|(_, page)| page)
+    pub fn iter<'a>(&'a self) -> slotmap::basic::Iter<'a, PageKey, Page> {
+        self.pages.iter()
     }
 }
 
@@ -91,6 +91,15 @@ impl IntoIterator for PageStore {
             .cloned()
             .collect::<Vec<_>>()
             .into_iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a PageStore {
+    type Item = (PageKey, &'a Page);
+    type IntoIter = slotmap::basic::Iter<'a, PageKey, Page>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
     }
 }
 

--- a/cmslib/src/util.rs
+++ b/cmslib/src/util.rs
@@ -5,7 +5,7 @@ use std::{
     path::{Path, PathBuf},
 };
 use tempfile::NamedTempFile;
-use tracing::instrument;
+use tracing::{instrument, trace};
 
 #[macro_export]
 macro_rules! static_regex {
@@ -35,6 +35,12 @@ pub fn get_all_templates(template_root: PathBuf) -> Result<Vec<PathBuf>, anyhow:
                 .unwrap_or_else(|| false)
         },
     )?)
+}
+
+#[instrument]
+pub fn make_parent_dirs<P: AsRef<Path> + std::fmt::Debug>(dir: P) -> Result<(), std::io::Error> {
+    trace!("create parent directories");
+    std::fs::create_dir_all(dir)
 }
 
 pub fn strip_root<P: AsRef<Path>>(root: P, path: P) -> PathBuf {

--- a/test/src/index.md
+++ b/test/src/index.md
@@ -3,11 +3,11 @@ title = "src root"
 template_path = "index_content.tera"
 
 [meta]
-sample = "lol"
+sample = "hi"
 +++
 
 *root/index markdown content!*
 
-here is some contentsample
+here is some ontentsample
 
 ![link](sample.txt)

--- a/test/src/sample.txt
+++ b/test/src/sample.txt
@@ -1,1 +1,1 @@
-hello
+hellooooo!!!

--- a/test/templates/index_content.tera
+++ b/test/templates/index_content.tera
@@ -17,7 +17,6 @@ script_context:
 {{ content | safe }}
 
 <pre><code>
-{{ __tera_context }}
 </code></pre>
 
 {% endblock body %}


### PR DESCRIPTION
The devserver mode will now process pipelines on-demand for each page request.

Remove duplicate page refresh

Pipelines are processed properly on source updates