### PR TITLE
Remove stale search keys

### DIFF
--- a/cmslib/src/core/engine.rs
+++ b/cmslib/src/core/engine.rs
@@ -128,7 +128,8 @@ impl Engine {
                                         &path,
                                         engine.renderers(),
                                     )?;
-                                    engine.page_store.upsert(page);
+                                    // update will automatically insert the page if it doesn't exist
+                                    let _ = engine.page_store.update(page);
                                 }
 
                                 if path.starts_with(&engine.config.template_root) {


### PR DESCRIPTION
Search keys are now updated in the page store when the `use_index`
frontmatter item is changed. This will ensure that the devserver doesn't
serve up pages that no longer exist at the provided address. This change
only impacts devserver mode and has no impact on building a site.