### PR TITLE
Add toast notification to devserver

### DIFF
--- a/cmslib/src/devserver/broker.rs
+++ b/cmslib/src/devserver/broker.rs
@@ -193,11 +193,15 @@ impl EngineBroker {
                         }
 
                         EngineMsg::FilesystemUpdate(events) => {
+                            let _ = broker.send_devserver_msg_sync(DevServerMsg::Notify(
+                                "buiding assets".to_owned(),
+                            ));
+
                             if let Err(e) = engine_msg::fs_event(&mut engine, events) {
-                                error!(error=%e, "file system error");
-                                let _ = broker.send_devserver_msg_sync(DevServerMsg::DisplayError(
-                                    e.to_string(),
-                                ));
+                                error!(error=%e, "fswatch error");
+                                let _ = broker
+                                    .send_devserver_msg_sync(DevServerMsg::Notify(e.to_string()));
+                                continue;
                             }
                             // notify websocket server to reload all connected clients
                             broker.send_devserver_msg_sync(DevServerMsg::ReloadPage)?;

--- a/cmslib/src/devserver/live-reload.js
+++ b/cmslib/src/devserver/live-reload.js
@@ -27,8 +27,12 @@
             log('Reloading page');
             location.reload();
             break;
-          case 'error':
-            log('do error');
+          case 'notify':
+            log(`recv notify msg: ${msg.payload}`);
+            const msgEl = document.getElementById("devserver-notify-payload");
+            msgEl.innerHTML = msg.payload;
+            const msgContainer = document.querySelector(".devserver-notify-container");
+            msgContainer.style.opacity = "1.0";
             break;
         }
       } else {

--- a/cmslib/src/devserver/responders.rs
+++ b/cmslib/src/devserver/responders.rs
@@ -39,8 +39,12 @@ fn error_page() -> &'static str {
 fn error_page_with_msg<S: AsRef<str>>(msg: S) -> String {
     let html = error_page().replace("{{ERROR}}", msg.as_ref());
     format!(
-        r#"{html}<script>{}</script>"#,
-        include_str!("live-reload.js")
+        r#"{html}
+        <script>{}</script>
+        <style>{}</style>
+        <div class="devserver-notify-container"><div id="devserver-notify-payload"></div></div>"#,
+        include_str!("live-reload.js"),
+        include_str!("toast.css")
     )
 }
 
@@ -50,8 +54,12 @@ fn page_not_found() -> String {
 
 fn html_with_live_reload_script(html: &str) -> String {
     format!(
-        r#"{html}<script>{}</script>"#,
-        include_str!("live-reload.js")
+        r#"{html}
+        <script>{}</script>
+        <style>{}</style>
+        <div class="devserver-notify-container"><div id="devserver-notify-payload"></div></div>"#,
+        include_str!("live-reload.js"),
+        include_str!("toast.css")
     )
 }
 

--- a/cmslib/src/devserver/toast.css
+++ b/cmslib/src/devserver/toast.css
@@ -1,0 +1,15 @@
+.devserver-notify-container {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    display: flex;
+    width: 100%;
+    justify-content: center;
+    background: #00e7ff;
+    margin: 0;
+    padding: 0;
+    padding-top: 1rem;
+    padding-bottom: 1rem;
+    font-weight: bold;
+    opacity: 0;
+}

--- a/test/src/index.md
+++ b/test/src/index.md
@@ -8,9 +8,8 @@ sample = "hi"
 
 *root/index markdown content!*
 
-here is some contentttt
+here is some content
 
-moar
-sup
+rebuild
 
 ![link](sample.txt)


### PR DESCRIPTION
The injected script can now display messages from the server. It only
supports displaying a single message at a time and will update
immediately whenever a message is received from the server. It is
currently only used to notify the user when assets are being built.