### PR TITLE
Add logging and verbose flags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -284,16 +284,16 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.1.18"
+version = "3.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2dbdf4bdacb33466e854ce889eee8dfd5729abf7ccd7664d0a2d60cd384440b"
+checksum = "d53da17d37dba964b9b3ecb5c5a1f193a2762c700e6829201e645b9381c99dc7"
 dependencies = [
  "atty",
  "bitflags",
  "clap_derive",
  "clap_lex",
  "indexmap",
- "lazy_static",
+ "once_cell",
  "strsim",
  "termcolor",
  "textwrap",
@@ -301,9 +301,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.1.18"
+version = "3.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25320346e922cffe59c0bbc5410c8d8784509efb321488971081313cb1e1a33c"
+checksum = "c11d40217d16aee8508cc8e5fde8b4ff24639758608e5374e731b53f85749fb9"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -314,9 +314,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a37c35f1112dad5e6e0b1adaff798507497a18fceeb30cceb3bae7d1427b9213"
+checksum = "5538cd660450ebeb4234cfecf8f2284b844ffc4c50531e66d584ad5b91293613"
 dependencies = [
  "os_str_bytes",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ publish = false
 name = "pylon"
 
 [dependencies]
-clap = { version = "3.1", features = ["derive", "env"] }
+clap = { version = "3.2", features = ["derive", "env"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["ansi", "env-filter"] }
 tracing-error = "0.2"

--- a/pylonlib/src/core/page/render.rs
+++ b/pylonlib/src/core/page/render.rs
@@ -2,7 +2,7 @@ use eyre::{eyre, WrapErr};
 use itertools::Itertools;
 use std::collections::HashSet;
 
-use tracing::{error, trace};
+use tracing::{debug, error, trace};
 
 use crate::{
     core::{
@@ -12,11 +12,15 @@ use crate::{
         Page,
     },
     site_context::SiteContext,
-    Result, SysPath,
+    Result, SysPath, USER_LOG,
 };
 
 pub fn render(engine: &Engine, page: &Page) -> Result<RenderedPage> {
-    trace!("rendering page");
+    debug!(
+        target: USER_LOG,
+        "rendering doc {}",
+        page.path().as_sys_path()
+    );
 
     let site_ctx = SiteContext::new("sample");
 

--- a/pylonlib/src/core/rules.rs
+++ b/pylonlib/src/core/rules.rs
@@ -60,11 +60,17 @@ impl PylonPipeline {
             target_glob,
         }
     }
+
     pub fn is_match<P: AsRef<Path>>(&self, asset: P) -> bool {
         self.target_glob.is_match(asset)
     }
+
     pub fn run(&self, asset_uri: &AssetUri) -> crate::Result<()> {
         self.pipeline.run(asset_uri)
+    }
+
+    pub fn glob(&self) -> &str {
+        self.target_glob.glob()
     }
 }
 

--- a/pylonlib/src/devserver/broker.rs
+++ b/pylonlib/src/devserver/broker.rs
@@ -183,9 +183,6 @@ impl EngineBroker {
             let _devserver = engine.start_devserver(bind, debounce_ms, broker.clone())?;
 
             loop {
-                if let Err(e) = handle_msg::mount_directories(&engine) {
-                    error!(err=%e, "failed mounting directories");
-                }
                 match broker.recv_engine_msg_sync() {
                     Ok(msg) => match msg {
                         EngineMsg::ProcessMounts(chan) => {

--- a/pylonlib/src/lib.rs
+++ b/pylonlib/src/lib.rs
@@ -20,9 +20,11 @@ pub mod util;
 pub use render::Renderers;
 pub use typed_path::*;
 
+use thiserror::Error;
+
 pub type Result<T> = eyre::Result<T>;
 
-use thiserror::Error;
+pub const USER_LOG: &str = "pylon_user";
 
 #[derive(Error, Debug)]
 #[error(transparent)]


### PR DESCRIPTION
Useful user-facing logs are now the default. It is possible to increase
the log level using -v or -vv (extra verbose).

A bug in the dev server was revealed by the implemented logs. The mounts
were being processed for every request sent by the browser, potentially
re-mounting directories many times for every image/script/css file in
the web page. Mounting will now only occur once every 1000ms whenever
the dev server gets a page request.