### PR TITLE
Remove assumed watch targets

### DIFF
--- a/pylonlib/src/core/engine.rs
+++ b/pylonlib/src/core/engine.rs
@@ -279,13 +279,12 @@ impl Engine {
             let paths = engine.paths();
 
             let watch_dirs = {
-                let mut dirs = vec![
-                    paths.absolute_template_dir(),
-                    paths.absolute_src_dir(),
-                    paths.absolute_rule_script(),
-                ];
+                // watch rule script
+                let mut dirs = vec![paths.absolute_rule_script()];
 
+                // watch mounts
                 dirs.extend(engine.rules().mounts().map(|mount| mount.src().clone()));
+                // watches within rule-script
                 dirs.extend(engine.rules().watches().cloned());
                 dirs
             };

--- a/pylonlib/src/init-resource/site-rules.rhai
+++ b/pylonlib/src/init-resource/site-rules.rhai
@@ -1,6 +1,7 @@
 rules.mount("web/wwwroot");
 
 rules.watch("web");
+rules.watch("content");
 
 rules.add_pipeline(".", "**/*.png", [OP_COPY]);
 rules.add_pipeline(".", "**/*.jpg", [OP_COPY]);


### PR DESCRIPTION
Only the site-rules script, mounts, and watches indicated in the
site-rules script are now watched. Previously, it was assumed that
`content/` and `web/` and `syntax-themes/` were always watched. Not
all sites will use `syntax-themes/`, so instead all assumed watches
were removed.

`web/` and `content/` are now watched manually in the site-rules script
instead of being assumed, and the default script that ships with Pylon
now includes these directores in the site-rules script.